### PR TITLE
Update the checkpoint for the first records processed after startup

### DIFF
--- a/lib/kcl/advanced_record_processor.rb
+++ b/lib/kcl/advanced_record_processor.rb
@@ -24,7 +24,8 @@ module Kcl
     def init shard_id
       LOG.info "Start consumming at shard: #{shard_id}"
       self.largest_seq = nil
-      self.last_checkpoint_time = Time.now
+      # So that first records through would update the checkpoint
+      self.last_checkpoint_time = Time.at(0)
     end
 
     def process_records records, checkpointer


### PR DESCRIPTION
This forces immediately checkpointing after the initial batch of records after a worker restarts.
