### PR TITLE
relax dependency to allow usage with rails 5

### DIFF
--- a/amazon-kinesis-client-ruby.gemspec
+++ b/amazon-kinesis-client-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '~> 4.1'
+  spec.add_runtime_dependency 'activesupport', '>= 4.1', '< 6.0'
   spec.add_runtime_dependency 'aws-kclrb', '~> 1.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
allows this gem to be used together with Rails 5:

```
Bundler could not find compatible versions for gem "activesupport":
  In snapshot (Gemfile.lock):
    activesupport (= 5.0.1)

  In Gemfile:
    amazon-kinesis-client-ruby was resolved to 0.0.1, which depends on
      activesupport (~> 4.1.8)
```